### PR TITLE
Fix peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Joel Arvidsson",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "=> 0.8.0 || 0.8.0-rc || 0.8.0-rc.2"
+    "react-native": ">=0.8.0 || 0.8.0-rc || 0.8.0-rc.2"
   },
   "dependencies": {
     "lodash": "^3.10.0"


### PR DESCRIPTION
It seems that `=>` is not properly recognized by npm, as it won't let me install `react-native-image-progress` unless I change the operator to `>=`.

This problem might also be the cause for [this fork](https://github.com/pkibbey/react-native-image-progress/commit/548b862f022242df841af65da56e48e655fbb740).