### PR TITLE
Minimize calls to setState as much as possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,11 @@ var ImageProgress = React.createClass({
   },
 
   handleLoadStart: function() {
+    if (this.state.loading || this.state.progress >= 1) {
+      // Minimize calls to setState!
+      return;
+    }
+
     this.setState({
       loading: true,
       progress: 0,
@@ -54,6 +59,11 @@ var ImageProgress = React.createClass({
     // 100% progress – sometimes in an infinite loop. So we just assume 100% progress
     // actually means the image is no longer loading
     var progress = event.nativeEvent.written / event.nativeEvent.total;
+    if (progress === this.state.progress) {
+      // Minimize calls to setState!
+      return;
+    }
+
     this.setState({
       loading: progress < 1,
       progress: progress,
@@ -62,6 +72,11 @@ var ImageProgress = React.createClass({
   },
 
   handleLoaded: function() {
+    if (this.state.progress === 1) {
+      // Minimize calls to setState!
+      return;
+    }
+
     this.setState({
       loading: false,
       progress: 1,


### PR DESCRIPTION
With this PR the amount of `setState` calls is reduced as much as possible and thus the number of `render` passes. This reduced the flickering of the loading indicator a lot in my app!

#### Before
```
13:28:38.611 [info] '============== render', { loading: true }
13:28:38.689 [info] 'handleLoadStart setState'
13:28:38.690 [info] 'handleLoadStart setState'
13:28:38.690 [info] 'handleLoadStart setState'
13:28:38.691 [info] '============== render', { loading: true }
13:28:38.705 [info] 'handleLoadProgress setState'
13:28:38.705 [info] 'handleLoaded setState'
13:28:38.705 [info] 'handleLoadProgress setState'
13:28:38.706 [info] 'handleLoaded setState'
13:28:38.706 [info] '============== render', { loading: false }
13:28:38.721 [info] 'handleLoadStart setState'
13:28:38.722 [info] 'handleLoadProgress setState'
13:28:38.722 [info] 'handleLoaded setState'
13:28:38.722 [info] '============== render', { loading: false }
```

#### After
```
13:29:07.873 [info] '============== render', { loading: true }
13:29:07.969 [info] 'handleLoadProgress setState'
13:29:07.969 [info] 'handleLoaded setState'
13:29:07.970 [info] 'handleLoadProgress setState'
13:29:07.970 [info] 'handleLoadProgress setState'
13:29:07.970 [info] 'handleLoaded setState'
13:29:07.970 [info] '============== render', { loading: false }
```

#### Notice

For this to work I assume that the image is loaded only once and does not somehow disappear! Do you know if its safe to make such a assumption? Is there a valid case for `onLoadStart` to be triggered after `onLoaded`?