### PR TITLE
Support changed property names of react-native 0.9.0-rc

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,40 +41,88 @@ var ImageProgress = React.createClass({
     }
   },
 
-  handleLoadStart: function() {
+  setStateStart: function() {
     if (!this.state.loading && this.state.progress !== 1) {
       this.setState({
         loading: true,
         progress: 0,
       });
     }
-    this.bubbleEvent('onLoadStart');
   },
 
-  handleLoadProgress: function(event) {
-    // RN is very buggy with these events, sometimes a loaded event and then a few
-    // 100% progress – sometimes in an infinite loop. So we just assume 100% progress
-    // actually means the image is no longer loading
-    var progress = event.nativeEvent.written / event.nativeEvent.total;
-    if (progress !== this.state.progress && this.state.progress !== 1) {
-      this.setState({
-        loading: progress < 1,
-        progress: progress,
-      });
-    }
-    this.bubbleEvent('onLoadProgress', event);
-  },
-
-  handleLoaded: function() {
+  setStateLoaded: function() {
     if (this.state.progress !== 1) {
       this.setState({
         loading: false,
         progress: 1,
       });
     }
+  },
+
+  setStateError: function() {
+    this.setState({
+      error: true,
+      loading: false,
+    });
+  },
+
+  setStateProgress: function(progress) {
+    // RN is very buggy with these events, sometimes a loaded event and then a few
+    // 100% progress – sometimes in an infinite loop. So we just assume 100% progress
+    // actually means the image is no longer loading
+    if (progress !== this.state.progress && this.state.progress !== 1) {
+      this.setState({
+        loading: progress < 1,
+        progress: progress,
+      });
+    }
+  },
+
+  // React>=0.8.0
+  handleLoadStart: function() {
+    this.setStateStart();
+    this.bubbleEvent('onLoadStart');
+  },
+
+  // React>=0.9.0
+  handleProgress: function(event) {
+    var progress = event.nativeEvent.loaded / event.nativeEvent.total;
+    this.setStateProgress(progress);
+    this.bubbleEvent('onProgress', event);
+  },
+
+  // React>=0.9.0
+  handleError: function(event) {
+    this.setStateError();
+    this.bubbleEvent('onError', event);
+  },
+
+  // React>=0.9.0
+  handleLoad: function(event) {
+    this.setStateLoaded();
+    this.bubbleEvent('onLoad', event);
+  },
+
+  // React>=0.9.0
+  handleLoadEnd: function(event) {
+    this.setStateLoaded();
+    this.bubbleEvent('onLoadEnd', event);
+  },
+
+  // React<0.9.0
+  handleLoadProgress: function(event) {
+    var progress = event.nativeEvent.written / event.nativeEvent.total;
+    this.setStateProgress(progress);
+    this.bubbleEvent('onLoadProgress', event);
+  },
+
+  // React<0.9.0
+  handleLoaded: function() {
+    this.setStateLoaded();
     this.bubbleEvent('onLoaded');
   },
 
+  // React<0.9.0
   handleLoadAbort: function() {
     this.setState({
       loading: false,
@@ -82,11 +130,9 @@ var ImageProgress = React.createClass({
     this.bubbleEvent('onLoadAbort');
   },
 
+  // React<0.9.0
   handleLoadError: function(event) {
-    this.setState({
-      error: true,
-      loading: false,
-    });
+    this.setStateError();
     this.bubbleEvent('onLoadError', event);
   },
 
@@ -144,11 +190,15 @@ var ImageProgress = React.createClass({
       <Image
         {...props}
         ref={component => this._root = component}
-        onLoadProgress={this.handleLoadProgress}
-        onLoadStart={this.handleLoadStart}
-        onLoaded={this.handleLoaded}
-        onLoadAbort={this.handleLoadAbort}
-        onLoadError={this.handleLoadError}
+        onLoadStart={this.handleLoadStart} // React>=0.8.0
+        onProgress={this.handleProgress} // React>=0.9.0
+        onError={this.handleError} // React>=0.9.0
+        onLoad={this.handleLoad} // React>=0.9.0
+        onLoadEnd={this.handleLoadEnd} // React>=0.9.0
+        onLoadAbort={this.handleLoadAbort} // React<0.9.0
+        onLoadError={this.handleLoadError} // React<0.9.0
+        onLoadProgress={this.handleLoadProgress} // React<0.9.0
+        onLoaded={this.handleLoaded} // React<0.9.0
       >
         {children}
       </Image>


### PR DESCRIPTION
Yay .. name changes! :disappointed: 

But with this we support both `react-native=0.9.0-rc` and `react-native<=0.8.x` 