### PR TITLE
Requiring React API from react-native is deprecated.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,13 @@
  */
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
 var {
   Image,
   View,
   StyleSheet,
   ActivityIndicatorIOS,
-} = React
+} = require('react-native');
 
 var ImageProgress = React.createClass({
   propTypes: {


### PR DESCRIPTION
After Updated to v0.25.1 , this warning always occurs on my Simulator. 
I fixed this.
<img width="279" alt="2016-05-17 12 44 00" src="https://cloud.githubusercontent.com/assets/4737631/15310650/15dadfae-1c2d-11e6-95fd-1dd54c35412f.png">

Please see blow URL. 
https://github.com/facebook/react-native/releases/tag/v0.25.1