### PR TITLE
Added the urlTimeout property, to stop showing an activity indicator when the url is broken.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Any [`Image` property](http://facebook.github.io/react-native/docs/image.html) a
 |**`indicatorProps`**|An object of props being passed to the `indicator` component. To disable indeterminate state, pass `{indeterminate: false}`.|*None*|
 |**`renderIndicator(progress, indeterminate)`**|Function to render your own custom indicator, useful for something very simple. If not, consider breaking it out to a separate component and use `indicator` prop instead.|*None*|
 |**`threshold`**|Number of milliseconds after mount to wait before displaying the indicator. Basically a workaround for cached images not to flash a spinner. Set to `0` to disable.|`50`|
+|**`urlTimeout`**|Number of milliseconds to wait before we stop showing the loading indicator (for example if an image url is broken). Set to `0` to disable.|`10000`|
 
 Note: `onLoad*` events are bubbled up, so if you wan't to do some custom thing when the image is loaded for example. 
 

--- a/index.js
+++ b/index.js
@@ -142,9 +142,11 @@ var ImageProgress = React.createClass({
         children = (<IndicatorComponent progress={progress} indeterminate={!loading || !progress} {...indicatorProps} />);
       }
     }
+    let source = (this.state.urlTimeoutReached===false)?this.props.source:this.props.defaultSource;
     return (
       <Image
         {...props}
+        source={source}
         ref={component => this._root = component}
         style={style}
         onLoadStart={this.handleLoadStart}

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var {
   Image,
   View,
   StyleSheet,
-  ActivityIndicatorIOS,
+  ActivityIndicator
 } = require('react-native');
 
 var ImageProgress = React.createClass({
@@ -112,14 +112,12 @@ var ImageProgress = React.createClass({
   },
 
   handleLoad: function(event) {
-    if (this.state.progress !== 1) {
-      //Image load complete for: "+this.props.source.uri
+    //Image load complete for: "+this.props.source.uri
       this.setState({
         loading: false,
         progress: 1,
         imageFetchedBeforeTimeout: true
       });
-    }
     this.bubbleEvent('onLoad', event);
   },
 
@@ -138,11 +136,11 @@ var ImageProgress = React.createClass({
       if(renderIndicator) {
         children = renderIndicator(progress, !loading || !progress);
       } else {
-        var IndicatorComponent = (typeof indicator === 'function' ? indicator : ActivityIndicatorIOS);
+        var IndicatorComponent = (typeof indicator === 'function' ? indicator : ActivityIndicator);
         children = (<IndicatorComponent progress={progress} indeterminate={!loading || !progress} {...indicatorProps} />);
       }
     }
-    let source = (this.state.urlTimeoutReached===false)?this.props.source:this.props.defaultSource;
+    let source = (this.state.urlTimeoutReached===true && this.state.imageFetchedBeforeTimeout===false)?this.props.defaultSource:this.props.source;
     return (
       <Image
         {...props}

--- a/index.js
+++ b/index.js
@@ -54,6 +54,9 @@ var ImageProgress = React.createClass({
     if(this._thresholdTimer) {
       clearTimeout(this._thresholdTimer);
     }
+    if(this._urlTimeoutTimer) {
+      clearTimeout(this._urlTimeoutTimer); 
+    }
   },
 
   bubbleEvent: function(propertyName, event) {

--- a/index.js
+++ b/index.js
@@ -3,13 +3,13 @@
  */
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
 var {
   Image,
   View,
   StyleSheet,
   ActivityIndicatorIOS,
-} = React
+} = require('react-native');
 
 var ImageProgress = React.createClass({
   propTypes: {


### PR DESCRIPTION
- Added a url timeout timer that makes the progress indicator stop when the image has not completed downloading after `urlTimeout` milliseconds.
- Updated the Readme.md file to let the user know how to change the urlTimeout property if needed.
