### PR TITLE
Updated to work with react-native >= 0.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Any [`Image` property](http://facebook.github.io/react-native/docs/image.html) a
 
 | Prop | Description | Default |
 |---|---|---|
-|**`indicator`**|A component to display progress, will be passed a `progress` prop with a number between 0 and 1 and `indeterminate` a boolean wether or not component has started recieveing data.|`ActivityIndicatorIOS`|
+|**`indicator`**|A component to display progress, will be passed a `progress` prop with a number between 0 and 1 and `indeterminate` a boolean wether or not component has started recieveing data.|`ActivityIndicator`|
 |**`indicatorProps`**|An object of props being passed to the `indicator` component. To disable indeterminate state, pass `{indeterminate: false}`.|*None*|
 |**`renderIndicator(progress, indeterminate)`**|Function to render your own custom indicator, useful for something very simple. If not, consider breaking it out to a separate component and use `indicator` prop instead.|*None*|
 |**`threshold`**|Number of milliseconds after mount to wait before displaying the indicator. Basically a workaround for cached images not to flash a spinner. Set to `0` to disable.|`50`|

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var {
   Image,
   View,
   StyleSheet,
-  ActivityIndicatorIOS,
+  ActivityIndicator,
 } = React
 
 var ImageProgress = React.createClass({
@@ -114,7 +114,7 @@ var ImageProgress = React.createClass({
       if(renderIndicator) {
         children = renderIndicator(progress, !loading || !progress);
       } else {
-        var IndicatorComponent = (typeof indicator === 'function' ? indicator : ActivityIndicatorIOS);
+        var IndicatorComponent = (typeof indicator === 'function' ? indicator : ActivityIndicator);
         children = (<IndicatorComponent progress={progress} indeterminate={!loading || !progress} {...indicatorProps} />);
       }
     }

--- a/index.js
+++ b/index.js
@@ -3,13 +3,14 @@
  */
 'use strict';
 
-var React = require('react-native');
+var ReactNative = require('react-native');
+var React = require('react')
 var {
   Image,
   View,
   StyleSheet,
   ActivityIndicator,
-} = React
+} = ReactNative
 
 var ImageProgress = React.createClass({
   propTypes: {


### PR DESCRIPTION
- React is require from react now, and the Views are from 'react-native'
- ActivityIndicatorIOS is deprecated now in favor of the crossplatform ActivityIndicator.