### PR TITLE
Add style support on wrapped image

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ import ProgressBar from 'react-native-progress/Bar';
 <Image 
   source={{ uri: 'http://loremflickr.com/640/480/dog' }} 
   indicator={ProgressBar} 
+  imageProps:{{
+    resizeMode: 'contain'
+  }}
   style={{
     width: 320, 
     height: 240, 
@@ -60,9 +63,6 @@ import Progress from 'react-native-progress';
     borderWidth: 0,
     color: 'rgba(150, 150, 150, 1)',
     unfilledColor: 'rgba(200, 200, 200, 0.2)'
-  }}
-  imageProps:{{
-    resizeMode: 'contain'
   }}
   style={{
     width: 320,

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Any [`Image` property](http://facebook.github.io/react-native/docs/image.html) a
 | Prop | Description | Default |
 |---|---|---|
 |**`indicator`**|A component to display progress, will be passed a `progress` prop with a number between 0 and 1 and `indeterminate` a boolean wether or not component has started recieveing data.|`ActivityIndicator`|
+|**`imageProps`**|An object containing style that will be applied to the wrapped image.|*absoluteFillObject* (position: 'absolute', top: 0, bottom: 0, left: 0, right: 0)|
 |**`indicatorProps`**|An object of props being passed to the `indicator` component. To disable indeterminate state, pass `{indeterminate: false}`.|*None*|
 |**`renderIndicator(progress, indeterminate)`**|Function to render your own custom indicator, useful for something very simple. If not, consider breaking it out to a separate component and use `indicator` prop instead.|*None*|
 |**`renderError(error)`**|Function to render your own custom error message or image fallback.|*None*|
@@ -59,6 +60,9 @@ import Progress from 'react-native-progress';
     borderWidth: 0,
     color: 'rgba(150, 150, 150, 1)',
     unfilledColor: 'rgba(200, 200, 200, 0.2)'
+  }}
+  imageProps:{{
+    resizeMode: 'contain'
   }}
   style={{
     width: 320,

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ export const createImageProgress = ImageComponent =>
       indicator: PropTypes.func,
       indicatorContainerStyle: PropTypes.any,
       indicatorProps: PropTypes.object,
+      imageProps: PropTypes.object,
       renderIndicator: PropTypes.func,
       renderError: PropTypes.func,
       source: PropTypes.any,
@@ -31,6 +32,7 @@ export const createImageProgress = ImageComponent =>
       indicatorContainerStyle: styles.centered,
       errorContainerStyle: styles.centered,
       threshold: 50,
+      imageProps: StyleSheet.absoluteFillObject,
     };
 
     static prefetch = Image.prefetch;
@@ -148,9 +150,11 @@ export const createImageProgress = ImageComponent =>
         renderIndicator,
         source,
         style,
-        threshold,
+        imageProps,
         ...props
       } = this.props;
+
+      const imageStyle = Object.assign({}, StyleSheet.absoluteFillObject, imageProps);
 
       if (!source || !source.uri) {
         // This is not a networked asset so fallback to regular image
@@ -200,7 +204,7 @@ export const createImageProgress = ImageComponent =>
             onError={this.handleError}
             onLoad={this.handleLoad}
             source={source}
-            style={StyleSheet.absoluteFill}
+            style={imageStyle}
           />
           {indicatorElement}
           {children}

--- a/index.js
+++ b/index.js
@@ -150,6 +150,7 @@ export const createImageProgress = ImageComponent =>
         renderIndicator,
         source,
         style,
+        threshold,
         imageProps,
         ...props
       } = this.props;


### PR DESCRIPTION
I add an imageProps parameter that should contain the style that must be applied to the wrapped image.
The style passed to the image will be combine with StyleSheet.absoluteFillObject (position: 'absolute', top: 0, bottom: 0, right: 0, left: 0).

I also update the ReadMe file.