### PR TITLE
Add borderRadius prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ export const createImageProgress = ImageComponent =>
       source: PropTypes.any,
       style: PropTypes.any,
       threshold: PropTypes.number.isRequired,
+      borderRadius: PropTypes.number,
     };
 
     static defaultProps = {
@@ -149,6 +150,7 @@ export const createImageProgress = ImageComponent =>
         source,
         style,
         threshold,
+        borderRadius,
         ...props
       } = this.props;
 
@@ -189,9 +191,8 @@ export const createImageProgress = ImageComponent =>
           <View style={indicatorContainerStyle}>{indicatorElement}</View>
         );
       }
-
       return (
-        <View style={style} ref={this.handleRef}>
+        <View style={[style, {borderRadius, overflow: 'hidden'}]} ref={this.handleRef}>
           <ImageComponent
             {...props}
             key={source && source.uri}
@@ -200,7 +201,7 @@ export const createImageProgress = ImageComponent =>
             onError={this.handleError}
             onLoad={this.handleLoad}
             source={source}
-            style={StyleSheet.absoluteFill}
+            style={[StyleSheet.absoluteFill, {borderRadius, overflow: 'hidden'}]}
           />
           {indicatorElement}
           {children}


### PR DESCRIPTION
Since you can't use `borderRadius` with `overflow: 'hidden'` on parent elements in Android, I've added an additional prop that would enable users to create images with rounded borders.