### PR TITLE
add support for onLoadEnd

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,6 +137,15 @@ export const createImageProgress = ImageComponent =>
       this.bubbleEvent('onLoad', event);
     };
 
+    onLoadEnd = event => {
+      this.setState({
+        error: null,
+        loading: false,
+        progress: 1,
+      });
+      this.bubbleEvent('onLoadEnd', event);
+    }
+
     render() {
       const {
         children,
@@ -199,6 +208,7 @@ export const createImageProgress = ImageComponent =>
             onProgress={this.handleProgress}
             onError={this.handleError}
             onLoad={this.handleLoad}
+            onLoadEnd={this.onLoadEnd}
             source={source}
             style={StyleSheet.absoluteFill}
           />


### PR DESCRIPTION
Image will trigger onLoadEnd when finish loading. Some lib (like FastImage) will only trigger this event when the image was loaded from cache. This code can prevent the loading progress still show  after the image has finish loading.