### PR TITLE
FIX: wrap static assets fallback image within a container

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,9 +155,14 @@ export const createImageProgress = ImageComponent =>
       if (!source || !source.uri) {
         // This is not a networked asset so fallback to regular image
         return (
-          <ImageComponent source={source} style={style} {...props}>
+          <View style={style} ref={this.handleRef}>
+            <ImageComponent
+              {...props}
+              source={source}
+              style={StyleSheet.absoluteFill}
+            />
             {children}
-          </ImageComponent>
+          </View>
         );
       }
       const { progress, thresholdReached, loading, error } = this.state;

--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ export const createImageProgress = ImageComponent =>
             <ImageComponent
               {...props}
               source={source}
-              style={StyleSheet.absoluteFill}
+              style={[StyleSheet.absoluteFill, imageStyle]}
             />
             {children}
           </View>


### PR DESCRIPTION
Wrap static assets fallback image within a container passing children to the self-closed Image component.
The related issue: #38 