### PR TITLE
Fixed clearing error by onLoadEnd

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ export const createImageProgress = ImageComponent =>
 
     onLoadEnd = event => {
       this.setState({
-        error: null,
+        ...this.state,
         loading: false,
         progress: 1,
       });


### PR DESCRIPTION
Currently when used in tandem with `react-native-fast-image`, error state is not being displayed, as `onLoadEnd` (which clears error from state) is always called at the end of loading cycle, whether loading succeeded or not.

1. onError - sets error
2. onLoadEnd - clears error

This PR changes this behavior, so that `onLoadEnd` preserves error state set up by previous lifecycle listeners